### PR TITLE
Improve .gitignore to ignore sub-directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
-/.nb-gradle/
-/.idea/
+### Gradle
 build/
+.gradle/
+
+### IntelliJ IDEA
+.idea/
+out/
 *.iml
-/fifty-states/.nb-gradle/
-/gluon-connect-rest-provider/.nb-gradle/
-/rubiks-cube/.nb-gradle/
+
+### Netbeans
+.nb-gradle/
+
+### Gluon
+gluoncloudlink_config.json

--- a/beacons/.gitignore
+++ b/beacons/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/cloudlink-rest-connector/.gitignore
+++ b/cloudlink-rest-connector/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/code-vault/.gitignore
+++ b/code-vault/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/comments/.gitignore
+++ b/comments/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/comments2.0/.gitignore
+++ b/comments2.0/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/doodle-trace/.gitignore
+++ b/doodle-trace/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/fifty-states/.gitignore
+++ b/fifty-states/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/gluon-SQLite-scala/.gitignore
+++ b/gluon-SQLite-scala/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/gluon-SQLite/.gitignore
+++ b/gluon-SQLite/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/gluon-connect-basic-usage/.gitignore
+++ b/gluon-connect-basic-usage/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/gluon-connect-file-provider/.gitignore
+++ b/gluon-connect-file-provider/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/gluon-connect-rest-provider/.gitignore
+++ b/gluon-connect-rest-provider/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/go-native/.gitignore
+++ b/go-native/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/helloworld/.gitignore
+++ b/helloworld/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/notes/.gitignore
+++ b/notes/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/

--- a/pws-gluoncloudlink-whiteboard/.gitignore
+++ b/pws-gluoncloudlink-whiteboard/.gitignore
@@ -1,3 +1,0 @@
-.idea/
-build/
-.gradle/

--- a/rubiks-cube/.gitignore
+++ b/rubiks-cube/.gitignore
@@ -1,4 +1,0 @@
-
-.gradle/
-.idea/
-build/


### PR DESCRIPTION
* PR improves ignoring of sub-directories like `.gradle`, `.idea` etc. from the parent `.gitignore` 
* Adding multiple `.gitignore` is difficult to maintain and many projects didn't had a `.gitignore`
* Also adds ignore for gluon specific file `gluoncloudlink_config.json`