### PR TITLE
Rename Client to GluonFX

### DIFF
--- a/HelloFX/README.md
+++ b/HelloFX/README.md
@@ -9,8 +9,8 @@ Read about this sample [here](https://docs.gluonhq.com/#_hellofx)
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -20,40 +20,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/HelloFX/pom.xml
+++ b/HelloFX/pom.xml
@@ -48,7 +48,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                     <target>${client.target}</target>
+                     <target>${gluonfx.target}</target>
                      <mainClass>${main.class}</mainClass>
                 </configuration>
             </plugin>
@@ -62,19 +62,19 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/HelloFX/pom.xml
+++ b/HelloFX/pom.xml
@@ -45,8 +45,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                      <target>${client.target}</target>
                      <mainClass>${main.class}</mainClass>

--- a/HelloFXML/README.md
+++ b/HelloFXML/README.md
@@ -9,8 +9,8 @@ Read about this sample [here](https://docs.gluonhq.com/#_hellofxml_sample)
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -20,40 +20,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/HelloFXML/pom.xml
+++ b/HelloFXML/pom.xml
@@ -50,8 +50,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <mainClass>${main.class}</mainClass>

--- a/HelloFXML/pom.xml
+++ b/HelloFXML/pom.xml
@@ -53,7 +53,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <mainClass>${main.class}</mainClass>
                     <bundlesList>
                         <list>hellofx.hello</list>
@@ -73,19 +73,19 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/HelloGluon/README.md
+++ b/HelloGluon/README.md
@@ -9,8 +9,8 @@ Read about this sample [here](https://docs.gluonhq.com/#_hellogluon_sample)
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -20,40 +20,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/HelloGluon/pom.xml
+++ b/HelloGluon/pom.xml
@@ -82,8 +82,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <attachList>

--- a/HelloGluon/pom.xml
+++ b/HelloGluon/pom.xml
@@ -85,7 +85,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -105,7 +105,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -134,13 +134,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/HelloMaps/README.md
+++ b/HelloMaps/README.md
@@ -1,12 +1,11 @@
 # HelloMaps
 
-A [Gluon Client](https://docs.gluonhq.com/client/) sample which makes use of [Gluon Maps](https://gluonhq.com/labs/maps/)
-to show a pinned location on a global map.
+HelloMaps which makes use of [Gluon Maps](https://gluonhq.com/labs/maps/) to show a pinned location on a global map.
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -16,40 +15,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/HelloMaps/pom.xml
+++ b/HelloMaps/pom.xml
@@ -93,8 +93,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <verbose>true</verbose>

--- a/HelloMaps/pom.xml
+++ b/HelloMaps/pom.xml
@@ -96,7 +96,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <verbose>true</verbose>
                     <attachList>
                         <list>display</list>
@@ -118,7 +118,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -161,13 +161,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/HelloWorld/README.md
+++ b/HelloWorld/README.md
@@ -9,8 +9,8 @@ Read about this sample [here](https://docs.gluonhq.com/#_helloworld)
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -20,40 +20,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/HelloWorld/pom.xml
+++ b/HelloWorld/pom.xml
@@ -31,7 +31,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                     <target>${client.target}</target>
+                     <target>${gluonfx.target}</target>
                      <mainClass>${main.class}</mainClass>
                 </configuration>
             </plugin>
@@ -45,19 +45,19 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/HelloWorld/pom.xml
+++ b/HelloWorld/pom.xml
@@ -28,8 +28,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                      <target>${client.target}</target>
                      <mainClass>${main.class}</mainClass>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gluon Samples
 
-Java, JavaFX and Gluon Mobile samples to run with Java 11+, GraalVM and the Gluon Client plugin for [Maven](https://github.com/gluonhq/client-maven-plugin/).
+Java, JavaFX and Gluon Mobile samples to run with Java 11+, GraalVM and the Gluon Client plugin for [Maven](https://github.com/gluonhq/gluonfx-maven-plugin/).
 
 The following platforms are currently supported:
 

--- a/alarm/README.md
+++ b/alarm/README.md
@@ -5,51 +5,51 @@ A JavaFX application that uses Gluon Mobile Glisten (a mobile application framew
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
 Run the application and explore all options using:
 
-    mvn client:runagent
+    mvn gluonfx:runagent
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/alarm/pom.xml
+++ b/alarm/pom.xml
@@ -118,8 +118,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <attachList>
@@ -131,7 +131,7 @@
                         <list>storage</list>
                     </attachList>
                     <mainClass>${main.class}</mainClass>
-                    <!-- Run mvn client:runagent to generate reflection, resources and bundles lists -->
+                    <!-- Run mvn javafx:runagent to generate reflection, resources and bundles lists -->
                 </configuration>
             </plugin>
         </plugins>

--- a/alarm/pom.xml
+++ b/alarm/pom.xml
@@ -121,7 +121,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -144,7 +144,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -173,13 +173,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/beacons/README.md
+++ b/beacons/README.md
@@ -10,8 +10,8 @@ Read how to create this sample step by step [here](https://docs.gluonhq.com/samp
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -21,40 +21,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/beacons/pom.xml
+++ b/beacons/pom.xml
@@ -90,8 +90,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${clientTarget}</target>
                     <attachList>

--- a/beacons/pom.xml
+++ b/beacons/pom.xml
@@ -93,7 +93,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${clientTarget}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>ble</list>
                         <list>display</list>
@@ -122,7 +122,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <clientTarget>host</clientTarget>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -151,13 +151,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <clientTarget>ios</clientTarget>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <clientTarget>android</clientTarget>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/cloudlink-cloudfirst-storage/README.md
+++ b/cloudlink-cloudfirst-storage/README.md
@@ -20,8 +20,8 @@ Read how to create this sample step by step [here](https://docs.gluonhq.com/samp
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -31,40 +31,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/cloudlink-cloudfirst-storage/pom.xml
+++ b/cloudlink-cloudfirst-storage/pom.xml
@@ -121,8 +121,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
                     <target>${client.target}</target>

--- a/cloudlink-cloudfirst-storage/pom.xml
+++ b/cloudlink-cloudfirst-storage/pom.xml
@@ -125,7 +125,7 @@
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -155,7 +155,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -184,13 +184,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/comments/README.md
+++ b/comments/README.md
@@ -20,8 +20,8 @@ Read how to create this sample step by step [here](https://docs.gluonhq.com/samp
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -31,40 +31,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/comments/pom.xml
+++ b/comments/pom.xml
@@ -108,7 +108,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <clientTarget>host</clientTarget>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -134,13 +134,13 @@
         <profile>
             <id>android</id>
             <properties>
-                <clientTarget>android</clientTarget>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>ios</id>
             <properties>
-                <clientTarget>ios</clientTarget>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
     </profiles>
@@ -167,7 +167,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${clientTarget}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>

--- a/comments/pom.xml
+++ b/comments/pom.xml
@@ -164,8 +164,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${clientTarget}</target>
                     <attachList>

--- a/doodle-trace/README.md
+++ b/doodle-trace/README.md
@@ -8,7 +8,7 @@ Read how to create this sample step by step here.
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
 Please follow the pre-requisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
@@ -19,40 +19,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/doodle-trace/pom.xml
+++ b/doodle-trace/pom.xml
@@ -82,7 +82,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -102,7 +102,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -131,13 +131,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/doodle-trace/pom.xml
+++ b/doodle-trace/pom.xml
@@ -79,8 +79,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <attachList>

--- a/fiftystates/README.md
+++ b/fiftystates/README.md
@@ -11,8 +11,8 @@ Read how to create this sample step by step [here](https://docs.gluonhq.com/samp
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -22,40 +22,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/fiftystates/pom.xml
+++ b/fiftystates/pom.xml
@@ -140,8 +140,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${clientTarget}</target>
                     <attachList>

--- a/fiftystates/pom.xml
+++ b/fiftystates/pom.xml
@@ -74,7 +74,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <clientTarget>host</clientTarget>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -110,13 +110,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <clientTarget>ios</clientTarget>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <clientTarget>android</clientTarget>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>
@@ -143,7 +143,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${clientTarget}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>cache</list>
                         <list>display</list>

--- a/gluon-connect-basic-usage/README.md
+++ b/gluon-connect-basic-usage/README.md
@@ -11,7 +11,7 @@ section on the Gluon Mobile documentation website.
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
 Please follow the pre-requisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
@@ -22,40 +22,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/gluon-connect-basic-usage/pom.xml
+++ b/gluon-connect-basic-usage/pom.xml
@@ -102,7 +102,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -126,7 +126,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -155,13 +155,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/gluon-connect-basic-usage/pom.xml
+++ b/gluon-connect-basic-usage/pom.xml
@@ -99,8 +99,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <attachList>

--- a/gluon-connect-file-provider/README.md
+++ b/gluon-connect-file-provider/README.md
@@ -11,8 +11,8 @@ section on the Gluon Connect documentation website.
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -22,40 +22,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/gluon-connect-file-provider/pom.xml
+++ b/gluon-connect-file-provider/pom.xml
@@ -99,8 +99,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
                     <target>${client.target}</target>

--- a/gluon-connect-file-provider/pom.xml
+++ b/gluon-connect-file-provider/pom.xml
@@ -103,7 +103,7 @@
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -126,7 +126,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -155,13 +155,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/gluon-connect-rest-provider/README.md
+++ b/gluon-connect-rest-provider/README.md
@@ -11,8 +11,8 @@ section on the Gluon Connect documentation website.
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -22,40 +22,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/gluon-connect-rest-provider/pom.xml
+++ b/gluon-connect-rest-provider/pom.xml
@@ -119,7 +119,7 @@
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -143,7 +143,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -172,13 +172,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/gluon-connect-rest-provider/pom.xml
+++ b/gluon-connect-rest-provider/pom.xml
@@ -115,8 +115,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
                     <target>${client.target}</target>

--- a/hello-tribuo/README.md
+++ b/hello-tribuo/README.md
@@ -4,7 +4,7 @@ This Gluon Client sample was generated from https://start.gluon.io
 
 ## Basic Requirements
 
-A list of the basic requirements can be found online in the [Gluon Client documentation](https://docs.gluonhq.com/#_requirements).
+A list of the basic requirements can be found online in the [Gluon documentation](https://docs.gluonhq.com/#_requirements).
 
 ## Quick instructions
 
@@ -14,15 +14,15 @@ A list of the basic requirements can be found online in the [Gluon Client docume
 
 ### Run the sample as a native image
 
-    mvn client:build client:run
+    mvn gluonfx:build gluonfx:run
 
 ### Run the sample as a native android image
 
-    mvn -Pandroid client:build client:package client:install client:run
+    mvn -Pandroid gluonfx:build gluonfx:package gluonfx:install gluonfx:run
 
 ### Run the sample as a native iOS image
 
-    mvn -Pios client:build client:package client:install client:run
+    mvn -Pios gluonfx:build gluonfx:package gluonfx:install gluonfx:run
 
 ## Selected features
 

--- a/hello-tribuo/pom.xml
+++ b/hello-tribuo/pom.xml
@@ -83,8 +83,8 @@
             </plugin>
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <mainClass>${main.class}</mainClass>

--- a/hello-tribuo/pom.xml
+++ b/hello-tribuo/pom.xml
@@ -86,7 +86,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <mainClass>${main.class}</mainClass>
                     <resourcesList>
                         <item>bezdekIris.data</item>
@@ -109,7 +109,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -138,13 +138,13 @@
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/notes/README.md
+++ b/notes/README.md
@@ -10,8 +10,8 @@ Read how to create this sample step by step [here](https://docs.gluonhq.com/samp
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -21,40 +21,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/notes/pom.xml
+++ b/notes/pom.xml
@@ -103,8 +103,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <attachList>

--- a/notes/pom.xml
+++ b/notes/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>
@@ -143,7 +143,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -172,13 +172,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <attach.version>4.0.11</attach.version>
         <connect.version>2.0.1</connect.version>
         <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
-        <gluonfx.maven.plugin.version>0.9.0-SNAPSHOT</gluonfx.maven.plugin.version>
+        <gluonfx.maven.plugin.version>0.9.1-SNAPSHOT</gluonfx.maven.plugin.version>
     </properties>
 
     <modules>
@@ -41,5 +41,16 @@
         <module>pushnotes</module>
         <module>rubiks-cube</module>
     </modules>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven-central</id>
+            <url>https://repo1.maven.apache.org/maven2/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>maven-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <attach.version>4.0.11</attach.version>
         <connect.version>2.0.1</connect.version>
         <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
-        <client.maven.plugin.version>0.1.42</client.maven.plugin.version>
+        <gluonfx.maven.plugin.version>0.9.0-SNAPSHOT</gluonfx.maven.plugin.version>
     </properties>
 
     <modules>

--- a/pushnotes/README.md
+++ b/pushnotes/README.md
@@ -18,8 +18,8 @@ Read how to create this sample step by step [here](https://docs.gluonhq.com/samp
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -29,40 +29,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/pushnotes/pom.xml
+++ b/pushnotes/pom.xml
@@ -117,8 +117,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${client.target}</target>
                     <attachList>

--- a/pushnotes/pom.xml
+++ b/pushnotes/pom.xml
@@ -120,7 +120,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${client.target}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>device</list>
                         <list>display</list>
@@ -161,7 +161,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <client.target>host</client.target>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -190,13 +190,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <client.target>ios</client.target>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <client.target>android</client.target>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>

--- a/rubiks-cube/README.md
+++ b/rubiks-cube/README.md
@@ -8,8 +8,8 @@ Read about how the JavaFX 3D Rubik's cube was originally implemented [here](http
 
 ## Quick Instructions
 
-We use [Gluon Client](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
-Please follow the Gluon Client prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
+We use [GluonFX plugin](https://docs.gluonhq.com/) to build a native image for platforms including desktop, android and iOS.
+Please follow the prerequisites as stated [here](https://docs.gluonhq.com/#_requirements).
 
 ### Desktop
 
@@ -19,40 +19,40 @@ Run the application using:
 
 Build a native image using:
 
-    mvn client:build
+    mvn gluonfx:build
 
 Run the native image app:
 
-    mvn client:run
+    mvn gluonfx:run
 
 ### Android
 
 Build a native image for Android using:
 
-    mvn client:build -Pandroid
+    mvn gluonfx:build -Pandroid
 
 Package the native image as an 'apk' file:
 
-    mvn client:package -Pandroid
+    mvn gluonfx:package -Pandroid
 
 Install it on a connected android device:
 
-    mvn client:install -Pandroid
+    mvn gluonfx:install -Pandroid
 
 Run the installed app on a connected android device:
 
-    mvn client:run -Pandroid
+    mvn gluonfx:run -Pandroid
 
 ### iOS
 
 Build a native image for iOS using:
 
-    mvn client:build -Pios
+    mvn gluonfx:build -Pios
 
 Install and run the native image on a connected iOS device:
 
-    mvn client:run -Pios
+    mvn gluonfx:run -Pios
 
 Create an IPA file (for submission to TestFlight or App Store):
 
-    mvn client:package -Pios
+    mvn gluonfx:package -Pios

--- a/rubiks-cube/pom.xml
+++ b/rubiks-cube/pom.xml
@@ -133,8 +133,8 @@
 
             <plugin>
                 <groupId>com.gluonhq</groupId>
-                <artifactId>client-maven-plugin</artifactId>
-                <version>${client.maven.plugin.version}</version>
+                <artifactId>gluonfx-maven-plugin</artifactId>
+                <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
                     <target>${clientTarget}</target>
                     <attachList>

--- a/rubiks-cube/pom.xml
+++ b/rubiks-cube/pom.xml
@@ -74,7 +74,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <clientTarget>host</clientTarget>
+                <gluonfx.target>host</gluonfx.target>
             </properties>
             <dependencies>
                 <dependency>
@@ -103,13 +103,13 @@
         <profile>
             <id>ios</id>
             <properties>
-                <clientTarget>ios</clientTarget>
+                <gluonfx.target>ios</gluonfx.target>
             </properties>
         </profile>
         <profile>
             <id>android</id>
             <properties>
-                <clientTarget>android</clientTarget>
+                <gluonfx.target>android</gluonfx.target>
             </properties>
         </profile>
     </profiles>
@@ -136,7 +136,7 @@
                 <artifactId>gluonfx-maven-plugin</artifactId>
                 <version>${gluonfx.maven.plugin.version}</version>
                 <configuration>
-                    <target>${clientTarget}</target>
+                    <target>${gluonfx.target}</target>
                     <attachList>
                         <list>display</list>
                         <list>lifecycle</list>


### PR DESCRIPTION
This PR renames the `client-maven-plugin` to `gluonfx-maven-plugin` and bumps the plugin version to `0.9.1-SNAPSHOT`.