### PR TITLE
SharedLib example for Windows

### DIFF
--- a/HelloSharedLib/run.bat
+++ b/HelloSharedLib/run.bat
@@ -1,0 +1,35 @@
+@echo off
+setlocal
+
+REM Store the machine architecture in a variable
+if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    set "arch=x86_64-windows"
+) else (
+    echo Unsupported architecture
+    exit /b 1
+)
+
+REM Setup Visual Studio compiler if it is not already on the PATH
+SET "VS2022_File=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat"
+SET "VS2019_File=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
+WHERE cl >nul 2>nul
+IF ERRORLEVEL 1 (
+    IF EXIST "%VS2022_File%" (
+        CALL "%VS2022_File%" x64
+        GOTO Compile
+    )
+    IF EXIST "%VS2019_File%" (
+        CALL "%VS2019_File%" x64
+        GOTO Compile
+    )
+    echo Warning: Both vcvarsall.bat files for Visual Studio 2022 and 2019 do not exist.
+)
+
+:Compile
+
+REM Compile and run the program if the architecture is supported
+cl /I "target\gluonfx\%arch%\gvm\HelloSharedLib" /EHsc sample/example.cpp /link "target\gluonfx\%arch%\HelloSharedLib.lib" /out:"target\gluonfx\%arch%\example.exe"
+
+"target\gluonfx\%arch%\example.exe" 1 2
+
+endlocal

--- a/HelloSharedLib/sample/example.cpp
+++ b/HelloSharedLib/sample/example.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 #include "hello.hellosharedlib.h"
 
 using namespace std;


### PR DESCRIPTION
This PR adds an example for compiling against the shared library generated on Windows. 

## Setup substrate snapshot

Install [substrate PR 1235](https://github.com/gluonhq/substrate/pull/1235) to the local maven repo: `gradlew publishToMavenLocal`

and modify the pom.xml:

```xml
<plugin>
    <groupId>com.gluonhq</groupId>
    <artifactId>gluonfx-maven-plugin</artifactId>
    <version>${gluonfx.maven.plugin.version}</version>
    <configuration>
        <target>${gluonfx.target}</target>
        <mainClass>${main.class}</mainClass>
    </configuration>

    <!-- Use the snapshot build of substrate -->
    <dependencies>
        <dependency>
            <groupId>com.gluonhq</groupId>
            <artifactId>substrate</artifactId>
            <version>0.0.61-SNAPSHOT</version>
        </dependency>
    </dependencies>

</plugin>
```

## Build on Windows

```bash
mvn gluonfx:sharedlib
run.bat
```

The output should be:

```text
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.6.3
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'

E:\HEBI\gluon\gluon-samples\HelloSharedLib>run
Microsoft (R) C/C++ Optimizing Compiler Version 19.36.32534 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

example.cpp
Microsoft (R) Incremental Linker Version 14.36.32534.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:example.exe
target\gluonfx\x86_64-windows\HelloSharedLib.lib
/out:target\gluonfx\x86_64-windows\example.exe
example.obj
Sum: 3
Diff: -1
Text: Hello from Java
```

